### PR TITLE
Fix gist demos since Reagent use new DOM namespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,13 +43,13 @@
           <div id="app-demo-list" class="hidden">
             <h1>re-playground</h1>
             <p>Try your hand at writing re-frame with reagent by starting with a
-               <a href="?gist-id=saskali/d9b7d0ccc36cdb89ef49a56a531e5b25">template</a>,
+               <a href="?gist-id=PrestanceDesign/22f1fc6b3a0c4b9aba70d497c450e945">template</a>,
                or investigate the examples below!</p>
             <h2>re-frame + reagent demos</h2>
             <ul>
-              <li><a href="?gist-id=daiyi/62db9d22136503a42cbbe5dc5ec0337d">hello world</a></li>
-              <li><a href="?gist-id=saskali/1398f41345ea4df551b0c370ac1ac822">timer</a></li>
-              <li><a href="?gist-id=saskali/2ab16d41d3313e7cfd2429064092c67c">color sorting</a></li>
+              <li><a href="?gist-id=PrestanceDesign/29a2c419feed735c1ae75e906dad5a0d">hello world</a></li>
+              <li><a href="?gist-id=PrestanceDesign/b6433653482f145d5e7959ae179fba43">timer</a></li>
+              <li><a href="?gist-id=PrestanceDesign/4b44a188ea3977b75603d312900656fb">color sorting</a></li>
               <!-- <li><a href="#">to-do list</a></li> -->
             </ul>
           </div>
@@ -85,7 +85,7 @@
           </p>
           <p>
               for example:
-              <a href="?gist-id=daiyi/62db9d22136503a42cbbe5dc5ec0337d">?gist-id=daiyi/62db9d22136503a42cbbe5dc5ec0337d</a>
+              <a href="?gist-id=PrestanceDesign/29a2c419feed735c1ae75e906dad5a0d">?gist-id=PrestanceDesign/29a2c419feed735c1ae75e906dad5a0d</a>
           </p>
       </div>
   </div>


### PR DESCRIPTION
Hi,

Reagent use now `reagent.dom` namespace for the render function, so all the demos no longer works.
I had fix all gists.

Best regards.